### PR TITLE
Add better formatting for slash commands

### DIFF
--- a/commands/career-rank.js
+++ b/commands/career-rank.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
+const { LINK_GAMERTAG_ID, LINK_GAMERTAG_NAME } = require("../constants");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -70,7 +71,7 @@ module.exports = {
         await interaction.reply({
           content:
             `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-            "They can use `/link-gamertag` at any time to do so.",
+            `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
           allowedMentions: { users: [member.id] },
           ephemeral: quiet,
         });

--- a/commands/check-bingo-card.js
+++ b/commands/check-bingo-card.js
@@ -8,6 +8,8 @@ const {
   HALOFUNTIME_ID_CHANNEL_BINGO_CHALLENGE,
   HALOFUNTIME_ID_ROLE_E1_BINGO_BUFF,
   HALOFUNTIME_ID_ROLE_STAFF,
+  LINK_GAMERTAG_ID,
+  LINK_GAMERTAG_NAME,
 } = require("../constants.js");
 const { ERA_DATA } = require("../utils/eras.js");
 const {
@@ -159,8 +161,7 @@ module.exports = {
           .setTitle("No Linked Gamertag Detected")
           .addFields({
             name: "🔗 Link your gamertag!",
-            value:
-              "> Link your Xbox Live Gamertag to HaloFunTime with the `/link-gamertag` command to participate in the Bingo Challenge! Once your gamertag is verified by Staff, the challenge will begin fetching your in-game data.",
+            value: `> Link your Xbox Live Gamertag to HaloFunTime with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to participate in the Bingo Challenge! Once your gamertag is verified by Staff, the challenge will begin fetching your in-game data.`,
           })
       );
     }

--- a/commands/csr.js
+++ b/commands/csr.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
+const { LINK_GAMERTAG_NAME, LINK_GAMERTAG_ID } = require("../constants");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -70,7 +71,7 @@ module.exports = {
         await interaction.reply({
           content:
             `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-            "They can use `/link-gamertag` at any time to do so.",
+            `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
           allowedMentions: { users: [member.id] },
           ephemeral: quiet,
         });

--- a/commands/gamertag.js
+++ b/commands/gamertag.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
+const { LINK_GAMERTAG_NAME, LINK_GAMERTAG_ID } = require("../constants");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -38,7 +39,7 @@ module.exports = {
       await interaction.reply({
         content:
           `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-          "They can use `/link-gamertag` at any time to do so.",
+          `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
         allowedMentions: { users: [member.id] },
       });
     } else {

--- a/commands/pathfinder-dynamo-progress.js
+++ b/commands/pathfinder-dynamo-progress.js
@@ -7,6 +7,8 @@ const {
   HALOFUNTIME_ID_EMOJI_HEART_PATHFINDERS,
   HALOFUNTIME_ID_ROLE_PATHFINDER,
   HALOFUNTIME_ID_THREAD_PATHFINDER_BOT_COMMANDS,
+  LINK_GAMERTAG_NAME,
+  LINK_GAMERTAG_ID,
 } = require("../constants.js");
 const {
   getCurrentSeason,
@@ -272,8 +274,7 @@ module.exports = {
       if (!response.linkedGamertag) {
         progressEmbed.addFields({
           name: "🔗 Link your gamertag!",
-          value:
-            "> Link your Xbox Live Gamertag to HaloFunTime with the `/link-gamertag` command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.",
+          value: `> Link your Xbox Live Gamertag to HaloFunTime with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.`,
         });
       }
       // Add the total field, footer, and timestamp

--- a/commands/recent-games.js
+++ b/commands/recent-games.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
+const { LINK_GAMERTAG_ID, LINK_GAMERTAG_NAME } = require("../constants");
 
 const MATCH_TYPE_CHOICES = [
   { name: "Matchmaking", value: "Matchmaking" },
@@ -92,7 +93,7 @@ module.exports = {
         await interaction.reply({
           content:
             `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-            "They can use `/link-gamertag` at any time to do so.",
+            `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
           allowedMentions: { users: [member.id] },
           ephemeral: quiet,
         });

--- a/commands/trailblazer-scout-progress.js
+++ b/commands/trailblazer-scout-progress.js
@@ -7,6 +7,8 @@ const {
   HALOFUNTIME_ID_EMOJI_PASSION,
   HALOFUNTIME_ID_ROLE_TRAILBLAZER,
   HALOFUNTIME_ID_THREAD_TRAILBLAZER_BOT_COMMANDS,
+  LINK_GAMERTAG_ID,
+  LINK_GAMERTAG_NAME,
 } = require("../constants.js");
 const {
   getCurrentSeason,
@@ -276,8 +278,7 @@ module.exports = {
       if (!response.linkedGamertag) {
         progressEmbed.addFields({
           name: "🔗 Link your gamertag!",
-          value:
-            "> Link your Xbox Live Gamertag to HaloFunTime with the `/link-gamertag` command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.",
+          value: `> Link your Xbox Live Gamertag to HaloFunTime with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.`,
         });
       }
       // Add the total field, footer, and timestamp

--- a/constants.js
+++ b/constants.js
@@ -112,4 +112,7 @@ module.exports = Object.freeze({
   PARTYTIMER_CAP: 5,
   PARTYTIMER_TOTAL_REP_MINIMUM: 50,
   PARTYTIMER_UNIQUE_REP_MINIMUM: 30,
+  // https://stackoverflow.com/a/73988996/15751555
+  LINK_GAMERTAG_ID: "1212551700301221936",
+  LINK_GAMERTAG_NAME: "link-gamertag",
 });

--- a/cron/membership.js
+++ b/cron/membership.js
@@ -30,6 +30,8 @@ const {
   PARTYTIMER_CAP,
   PARTYTIMER_TOTAL_REP_MINIMUM,
   PARTYTIMER_UNIQUE_REP_MINIMUM,
+  LINK_GAMERTAG_NAME,
+  LINK_GAMERTAG_ID,
 } = require("../constants.js");
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -204,8 +206,7 @@ const updateNewHereRoles = async (client) => {
     welcomeDM += `I've added you to the <#${HALOFUNTIME_ID_CHANNEL_NEW_HERE}> channel for the next 28 days. `;
     welcomeDM +=
       "It's a great place to meet people, learn about the server, and chat directly with the Staff.\n\n";
-    welcomeDM +=
-      "When you get a chance, please use the `/link-gamertag` command to link your Xbox Live gamertag. ";
+    welcomeDM += `When you get a chance, please use the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to link your Xbox Live gamertag. `;
     welcomeDM +=
       "HaloFunTime uses your linked gamertag to pull data from Halo Infinite, assign special roles, and ";
     welcomeDM += "otherwise make sure everyone has a fun time!";
@@ -446,7 +447,7 @@ const updateRankedRoles = async (client) => {
       const congratsMessage =
         congratulationMessages.join("\n") +
         `\n\n> *To get a rank role, get the* <@&${HALOFUNTIME_ID_ROLE_RANKED}> *role from <id:customize> and link ` +
-        "your gamertag with the `/link-gamertag` command. Rank roles are assigned based on the highest rank you have " +
+        `your gamertag with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command. Rank roles are assigned based on the highest rank you have ` +
         "achieved during the current ranking period, and updated every fifteen minutes. Removing the* " +
         `<@&${HALOFUNTIME_ID_ROLE_RANKED}> *role or changing your linked gamertag will remove your rank role.*`;
       const channel = client.channels.cache.get(

--- a/cron/pathfinders.js
+++ b/cron/pathfinders.js
@@ -12,6 +12,8 @@ const {
   HALOFUNTIME_ID_ROLE_PATHFINDER_PRODIGY,
   HALOFUNTIME_ID_ROLE_PATHFINDER,
   HALOFUNTIME_ID,
+  LINK_GAMERTAG_ID,
+  LINK_GAMERTAG_NAME,
 } = require("../constants.js");
 const scheduledEvents = require("../utils/scheduledEvents");
 const { ERA_DATA, getCurrentEra } = require("../utils/eras");
@@ -345,7 +347,7 @@ const weeklyPopularFilesReport = async (client) => {
         `# __Popular HaloFunTime Files: <t:${now.unix()}:D>__\n\n` +
         "Every week we spotlight the top 10 most popular HaloFunTime files, sorted by recent play count.\n\n" +
         "**Tag your published files in-game with 'halofuntime' to be included!**\n\n" +
-        "Link your gamertag with `/link-gamertag` to show up as a tagged contributor.",
+        `Link your gamertag with </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> to show up as a tagged contributor.`,
       embeds: embeds,
     });
     await message.react(HALOFUNTIME_ID_EMOJI_HALOFUNTIME_DOT_COM);

--- a/cron/trailblazers.js
+++ b/cron/trailblazers.js
@@ -13,6 +13,8 @@ const {
   HALOFUNTIME_ID_ROLE_TRAILBLAZER,
   HALOFUNTIME_ID_ROLE_TRAILBLAZER_TITAN,
   HALOFUNTIME_ID,
+  LINK_GAMERTAG_ID,
+  LINK_GAMERTAG_NAME,
 } = require("../constants.js");
 const scheduledEvents = require("../utils/scheduledEvents");
 const { ERA_DATA } = require("../utils/eras");
@@ -383,7 +385,7 @@ const trailblazerDailyPassionReport = async (client) => {
       .setColor(0xf93a2f)
       .setTitle(`__Daily Passion Report: <t:${now.unix()}:D>__`)
       .setDescription(
-        "Every day we check each Trailblazer's passion in the Ranked Arena playlist. Link your gamertag with `/link-gamertag` to be included."
+        `Every day we check each Trailblazer's passion in the Ranked Arena playlist. Link your gamertag with </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> to be included.`
       )
       .setFooter({
         text: `"${passionReportQuip}"`,


### PR DESCRIPTION
This adds better formatting for slash commands using Discord's new slash command formatting ([docs](https://discord.com/developers/docs/reference#message-formatting-formats)), which looks like this:

![Discord_JR2BFxWsvD](https://github.com/HaloFunTime/hft-intern/assets/81275769/97102377-9b0e-4171-b01f-dedc2318a9ed)

It's also interactable, so users can execute the command quicker.

### Configuring the command ID
> [!NOTE]
> Make sure `Developer Mode` is enabled!
1. Type `/link-gamertag`
1. Right click the box above with the name and description of the command
1. Click `Copy Command ID`
1. Replace `LINK_GAMERTAG_ID` in [`constants.js`](https://github.com/Turtlepaw/hft-intern/blob/ebe421ceb145760829c74cebc20a1f71fb2e0c77/constants.js#L116) with the ID you've copied

![Discord_2Uk0760THN](https://github.com/HaloFunTime/hft-intern/assets/81275769/30183d3f-42b9-4886-872d-bf565e67f55a)
