### PR TITLE
Add better formatting for slash commands

### DIFF
--- a/commands/career-rank.js
+++ b/commands/career-rank.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder, SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
-const { LINK_GAMERTAG_ID, LINK_GAMERTAG_NAME } = require("../constants");
+const { LINK_GAMERTAG_NAME } = require("../constants");
+const { getApplicationCommandMention } = require("../utils/formatting");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -67,11 +68,15 @@ module.exports = {
           console.error(error);
         });
       if ("error" in response) {
+        const command = await getApplicationCommandMention(
+          LINK_GAMERTAG_NAME,
+          interaction.client
+        );
         // Send a reply that potentially pings the member if they haven't linked a gamertag
         await interaction.reply({
           content:
             `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-            `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
+            `They can use ${command} at any time to do so.`,
           allowedMentions: { users: [member.id] },
           ephemeral: quiet,
         });

--- a/commands/career-rank.js
+++ b/commands/career-rank.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
+const { LINK_GAMERTAG_ID, LINK_GAMERTAG_NAME } = require("../constants");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -70,7 +71,7 @@ module.exports = {
         await interaction.reply({
           content:
             `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-            "They can use `/link-gamertag` at any time to do so.",
+            `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
           allowedMentions: { users: [member.id] },
           ephemeral: quiet,
         });

--- a/commands/check-bingo-card.js
+++ b/commands/check-bingo-card.js
@@ -8,6 +8,8 @@ const {
   HALOFUNTIME_ID_CHANNEL_BINGO_CHALLENGE,
   HALOFUNTIME_ID_ROLE_E1_BINGO_BUFF,
   HALOFUNTIME_ID_ROLE_STAFF,
+  LINK_GAMERTAG_ID,
+  LINK_GAMERTAG_NAME,
 } = require("../constants.js");
 const { ERA_DATA } = require("../utils/eras.js");
 const {
@@ -159,8 +161,7 @@ module.exports = {
           .setTitle("No Linked Gamertag Detected")
           .addFields({
             name: "🔗 Link your gamertag!",
-            value:
-              "> Link your Xbox Live Gamertag to HaloFunTime with the `/link-gamertag` command to participate in the Bingo Challenge! Once your gamertag is verified by Staff, the challenge will begin fetching your in-game data.",
+            value: `> Link your Xbox Live Gamertag to HaloFunTime with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to participate in the Bingo Challenge! Once your gamertag is verified by Staff, the challenge will begin fetching your in-game data.`,
           })
       );
     }

--- a/commands/check-bingo-card.js
+++ b/commands/check-bingo-card.js
@@ -17,6 +17,7 @@ const {
   scoreBingo,
   LETTER_TO_HFT_EMOJI,
 } = require("../utils/era01.js");
+const { getApplicationCommandMention } = require("../utils/formatting.js");
 
 const hintQuipClauses = [
   "Keep this between you and me, but in case you were wondering... ",
@@ -154,6 +155,10 @@ module.exports = {
         )
       );
     } else {
+      const command = await getApplicationCommandMention(
+        LINK_GAMERTAG_NAME,
+        interaction.client
+      );
       // Add a gamertag link prompt embed instead if no gamertag is linked
       embeds.push(
         new EmbedBuilder()
@@ -161,7 +166,7 @@ module.exports = {
           .setTitle("No Linked Gamertag Detected")
           .addFields({
             name: "🔗 Link your gamertag!",
-            value: `> Link your Xbox Live Gamertag to HaloFunTime with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to participate in the Bingo Challenge! Once your gamertag is verified by Staff, the challenge will begin fetching your in-game data.`,
+            value: `> Link your Xbox Live Gamertag to HaloFunTime with the ${command} command to participate in the Bingo Challenge! Once your gamertag is verified by Staff, the challenge will begin fetching your in-game data.`,
           })
       );
     }

--- a/commands/csr.js
+++ b/commands/csr.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
+const { LINK_GAMERTAG_NAME, LINK_GAMERTAG_ID } = require("../constants");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -70,7 +71,7 @@ module.exports = {
         await interaction.reply({
           content:
             `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-            "They can use `/link-gamertag` at any time to do so.",
+            `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
           allowedMentions: { users: [member.id] },
           ephemeral: quiet,
         });

--- a/commands/csr.js
+++ b/commands/csr.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder, SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
 const { LINK_GAMERTAG_NAME, LINK_GAMERTAG_ID } = require("../constants");
+const { getApplicationCommandMention } = require("../utils/formatting");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -67,11 +68,15 @@ module.exports = {
           console.error(error);
         });
       if ("error" in response) {
+        const command = await getApplicationCommandMention(
+          LINK_GAMERTAG_NAME,
+          interaction.client
+        );
         // Send a reply that potentially pings the member if they haven't linked a gamertag
         await interaction.reply({
           content:
             `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-            `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
+            `They can use ${command} at any time to do so.`,
           allowedMentions: { users: [member.id] },
           ephemeral: quiet,
         });

--- a/commands/gamertag.js
+++ b/commands/gamertag.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
 const { LINK_GAMERTAG_NAME, LINK_GAMERTAG_ID } = require("../constants");
+const { getApplicationCommandMention } = require("../utils/formatting");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -35,11 +36,15 @@ module.exports = {
         console.error(error);
       });
     if ("error" in response) {
+      const command = await getApplicationCommandMention(
+        LINK_GAMERTAG_NAME,
+        interaction.client
+      );
       // Send a reply that pings the user if they haven't linked a gamertag
       await interaction.reply({
         content:
           `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-          `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
+          `They can use ${command} at any time to do so.`,
         allowedMentions: { users: [member.id] },
       });
     } else {

--- a/commands/gamertag.js
+++ b/commands/gamertag.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
+const { LINK_GAMERTAG_NAME, LINK_GAMERTAG_ID } = require("../constants");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -38,7 +39,7 @@ module.exports = {
       await interaction.reply({
         content:
           `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-          "They can use `/link-gamertag` at any time to do so.",
+          `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
         allowedMentions: { users: [member.id] },
       });
     } else {

--- a/commands/pathfinder-dynamo-progress.js
+++ b/commands/pathfinder-dynamo-progress.js
@@ -7,6 +7,8 @@ const {
   HALOFUNTIME_ID_EMOJI_HEART_PATHFINDERS,
   HALOFUNTIME_ID_ROLE_PATHFINDER,
   HALOFUNTIME_ID_THREAD_PATHFINDER_BOT_COMMANDS,
+  LINK_GAMERTAG_NAME,
+  LINK_GAMERTAG_ID,
 } = require("../constants.js");
 const {
   getCurrentSeason,
@@ -272,8 +274,7 @@ module.exports = {
       if (!response.linkedGamertag) {
         progressEmbed.addFields({
           name: "🔗 Link your gamertag!",
-          value:
-            "> Link your Xbox Live Gamertag to HaloFunTime with the `/link-gamertag` command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.",
+          value: `> Link your Xbox Live Gamertag to HaloFunTime with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.`,
         });
       }
       // Add the total field, footer, and timestamp

--- a/commands/pathfinder-dynamo-progress.js
+++ b/commands/pathfinder-dynamo-progress.js
@@ -17,6 +17,7 @@ const {
   SEASON_05,
 } = require("../utils/seasons");
 const { getCurrentEra, ERA_DATA } = require("../utils/eras");
+const { getApplicationCommandMention } = require("../utils/formatting.js");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -272,9 +273,14 @@ module.exports = {
       }
       // Add the gamertag link prompt field if needed
       if (!response.linkedGamertag) {
+        const command = await getApplicationCommandMention(
+          LINK_GAMERTAG_NAME,
+          interaction.client
+        );
+
         progressEmbed.addFields({
           name: "🔗 Link your gamertag!",
-          value: `> Link your Xbox Live Gamertag to HaloFunTime with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.`,
+          value: `> Link your Xbox Live Gamertag to HaloFunTime with the ${command} command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.`,
         });
       }
       // Add the total field, footer, and timestamp

--- a/commands/recent-games.js
+++ b/commands/recent-games.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder, SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
 const { LINK_GAMERTAG_ID, LINK_GAMERTAG_NAME } = require("../constants");
+const { getApplicationCommandMention } = require("../utils/formatting");
 
 const MATCH_TYPE_CHOICES = [
   { name: "Matchmaking", value: "Matchmaking" },
@@ -89,11 +90,15 @@ module.exports = {
           console.error(error);
         });
       if ("error" in response) {
+        const command = await getApplicationCommandMention(
+          LINK_GAMERTAG_NAME,
+          interaction.client
+        );
         // Send a reply that potentially pings the member if they haven't linked a gamertag
         await interaction.reply({
           content:
             `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-            `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
+            `They can use ${command} at any time to do so.`,
           allowedMentions: { users: [member.id] },
           ephemeral: quiet,
         });

--- a/commands/recent-games.js
+++ b/commands/recent-games.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, SlashCommandBuilder } = require("discord.js");
 const axios = require("axios");
+const { LINK_GAMERTAG_ID, LINK_GAMERTAG_NAME } = require("../constants");
 
 const MATCH_TYPE_CHOICES = [
   { name: "Matchmaking", value: "Matchmaking" },
@@ -92,7 +93,7 @@ module.exports = {
         await interaction.reply({
           content:
             `<@${member.id}> hasn't linked a gamertag on HaloFunTime. ` +
-            "They can use `/link-gamertag` at any time to do so.",
+            `They can use </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> at any time to do so.`,
           allowedMentions: { users: [member.id] },
           ephemeral: quiet,
         });

--- a/commands/trailblazer-scout-progress.js
+++ b/commands/trailblazer-scout-progress.js
@@ -17,6 +17,7 @@ const {
   SEASON_05,
 } = require("../utils/seasons");
 const { getCurrentEra, ERA_DATA } = require("../utils/eras");
+const { getApplicationCommandMention } = require("../utils/formatting.js");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -276,9 +277,14 @@ module.exports = {
       }
       // Add the gamertag link prompt field if needed
       if (!response.linkedGamertag) {
+        const command = await getApplicationCommandMention(
+          LINK_GAMERTAG_NAME,
+          interaction.client
+        );
+
         progressEmbed.addFields({
           name: "🔗 Link your gamertag!",
-          value: `> Link your Xbox Live Gamertag to HaloFunTime with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.`,
+          value: `> Link your Xbox Live Gamertag to HaloFunTime with the ${command} command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.`,
         });
       }
       // Add the total field, footer, and timestamp

--- a/commands/trailblazer-scout-progress.js
+++ b/commands/trailblazer-scout-progress.js
@@ -7,6 +7,8 @@ const {
   HALOFUNTIME_ID_EMOJI_PASSION,
   HALOFUNTIME_ID_ROLE_TRAILBLAZER,
   HALOFUNTIME_ID_THREAD_TRAILBLAZER_BOT_COMMANDS,
+  LINK_GAMERTAG_ID,
+  LINK_GAMERTAG_NAME,
 } = require("../constants.js");
 const {
   getCurrentSeason,
@@ -276,8 +278,7 @@ module.exports = {
       if (!response.linkedGamertag) {
         progressEmbed.addFields({
           name: "🔗 Link your gamertag!",
-          value:
-            "> Link your Xbox Live Gamertag to HaloFunTime with the `/link-gamertag` command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.",
+          value: `> Link your Xbox Live Gamertag to HaloFunTime with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to unlock additional challenges tied to your in-game stats! Once your gamertag is verified by Staff, you'll see additional challenges in this section.`,
         });
       }
       // Add the total field, footer, and timestamp

--- a/constants.js
+++ b/constants.js
@@ -112,4 +112,7 @@ module.exports = Object.freeze({
   PARTYTIMER_CAP: 5,
   PARTYTIMER_TOTAL_REP_MINIMUM: 50,
   PARTYTIMER_UNIQUE_REP_MINIMUM: 30,
+  // https://stackoverflow.com/a/73988996/15751555
+  LINK_GAMERTAG_ID: "1212551700301221936",
+  LINK_GAMERTAG_NAME: "link-gamertag",
 });

--- a/cron/membership.js
+++ b/cron/membership.js
@@ -33,6 +33,7 @@ const {
   LINK_GAMERTAG_NAME,
   LINK_GAMERTAG_ID,
 } = require("../constants.js");
+const { getApplicationCommandMention } = require("../utils/formatting.js");
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
@@ -148,6 +149,9 @@ const updateNewHereRoles = async (client) => {
   const now = dayjs();
   const twentyEightDaysAgoUnix = now.subtract(28, "day").valueOf();
   const guild = client.guilds.cache.get(HALOFUNTIME_ID);
+  // When developing the bot may not be in the
+  // HFT server so the crashes when it can't fetch the guild
+  if (!guild) return;
   const allMembersMap = await guild.members.fetch({
     cache: true,
     withUserCount: true,
@@ -194,6 +198,10 @@ const updateNewHereRoles = async (client) => {
       `Welcome to the <#${HALOFUNTIME_ID_CHANNEL_NEW_HERE}> channel, <@${member.user.id}>! ${quip}`
     );
     message.react("👋");
+    const linkCommand = await getApplicationCommandMention(
+      LINK_GAMERTAG_NAME,
+      interaction.client
+    );
     let welcomeDM = "";
     welcomeDM += `Welcome to HaloFunTime, <@${member.user.id}>! I'm the Intern, HaloFunTime's favorite bot.\n\n`;
     welcomeDM +=
@@ -206,7 +214,7 @@ const updateNewHereRoles = async (client) => {
     welcomeDM += `I've added you to the <#${HALOFUNTIME_ID_CHANNEL_NEW_HERE}> channel for the next 28 days. `;
     welcomeDM +=
       "It's a great place to meet people, learn about the server, and chat directly with the Staff.\n\n";
-    welcomeDM += `When you get a chance, please use the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to link your Xbox Live gamertag. `;
+    welcomeDM += `When you get a chance, please use the ${linkCommand} command to link your Xbox Live gamertag. `;
     welcomeDM +=
       "HaloFunTime uses your linked gamertag to pull data from Halo Infinite, assign special roles, and ";
     welcomeDM += "otherwise make sure everyone has a fun time!";
@@ -377,6 +385,9 @@ const updatePartyTimerRoles = async (client) => {
 const updateRankedRoles = async (client) => {
   console.log("Checking Ranked roles...");
   const guild = client.guilds.cache.get(HALOFUNTIME_ID);
+  // When developing the bot may not be in the
+  // HFT server so the crashes when it can't fetch the guild
+  if (!guild) return;
   const allMembersMap = await guild.members.fetch({
     cache: true,
     withUserCount: true,

--- a/cron/membership.js
+++ b/cron/membership.js
@@ -30,6 +30,8 @@ const {
   PARTYTIMER_CAP,
   PARTYTIMER_TOTAL_REP_MINIMUM,
   PARTYTIMER_UNIQUE_REP_MINIMUM,
+  LINK_GAMERTAG_NAME,
+  LINK_GAMERTAG_ID,
 } = require("../constants.js");
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -204,8 +206,7 @@ const updateNewHereRoles = async (client) => {
     welcomeDM += `I've added you to the <#${HALOFUNTIME_ID_CHANNEL_NEW_HERE}> channel for the next 28 days. `;
     welcomeDM +=
       "It's a great place to meet people, learn about the server, and chat directly with the Staff.\n\n";
-    welcomeDM +=
-      "When you get a chance, please use the `/link-gamertag` command to link your Xbox Live gamertag. ";
+    welcomeDM += `When you get a chance, please use the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command to link your Xbox Live gamertag. `;
     welcomeDM +=
       "HaloFunTime uses your linked gamertag to pull data from Halo Infinite, assign special roles, and ";
     welcomeDM += "otherwise make sure everyone has a fun time!";
@@ -446,7 +447,7 @@ const updateRankedRoles = async (client) => {
       const congratsMessage =
         congratulationMessages.join("\n") +
         `\n\n> *To get a rank role, get the* <@&${HALOFUNTIME_ID_ROLE_RANKED}> *role from <id:customize> and link ` +
-        "your gamertag with the `/link-gamertag` command. Rank roles are assigned based on the highest rank you have " +
+        `your gamertag with the </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> command. Rank roles are assigned based on the highest rank you have ` +
         "achieved during the current ranking period, and updated every fifteen minutes. Removing the* " +
         `<@&${HALOFUNTIME_ID_ROLE_RANKED}> *role or changing your linked gamertag will remove your rank role.*`;
       const channel = client.channels.cache.get(

--- a/cron/pathfinders.js
+++ b/cron/pathfinders.js
@@ -18,6 +18,7 @@ const {
 const scheduledEvents = require("../utils/scheduledEvents");
 const { ERA_DATA, getCurrentEra } = require("../utils/eras");
 const { getDateTimeForPathfinderEventStart } = require("../utils/pathfinders");
+const { getApplicationCommandMention } = require("../utils/formatting.js");
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -342,12 +343,16 @@ const weeklyPopularFilesReport = async (client) => {
     const spotlightChannel = client.channels.cache.get(
       HALOFUNTIME_ID_CHANNEL_SPOTLIGHT
     );
+    const command = await getApplicationCommandMention(
+      LINK_GAMERTAG_NAME,
+      interaction.client
+    );
     const message = await spotlightChannel.send({
       content:
         `# __Popular HaloFunTime Files: <t:${now.unix()}:D>__\n\n` +
         "Every week we spotlight the top 10 most popular HaloFunTime files, sorted by recent play count.\n\n" +
         "**Tag your published files in-game with 'halofuntime' to be included!**\n\n" +
-        `Link your gamertag with </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> to show up as a tagged contributor.`,
+        `Link your gamertag with ${command} to show up as a tagged contributor.`,
       embeds: embeds,
     });
     await message.react(HALOFUNTIME_ID_EMOJI_HALOFUNTIME_DOT_COM);

--- a/cron/pathfinders.js
+++ b/cron/pathfinders.js
@@ -12,6 +12,8 @@ const {
   HALOFUNTIME_ID_ROLE_PATHFINDER_PRODIGY,
   HALOFUNTIME_ID_ROLE_PATHFINDER,
   HALOFUNTIME_ID,
+  LINK_GAMERTAG_ID,
+  LINK_GAMERTAG_NAME,
 } = require("../constants.js");
 const scheduledEvents = require("../utils/scheduledEvents");
 const { ERA_DATA, getCurrentEra } = require("../utils/eras");
@@ -345,7 +347,7 @@ const weeklyPopularFilesReport = async (client) => {
         `# __Popular HaloFunTime Files: <t:${now.unix()}:D>__\n\n` +
         "Every week we spotlight the top 10 most popular HaloFunTime files, sorted by recent play count.\n\n" +
         "**Tag your published files in-game with 'halofuntime' to be included!**\n\n" +
-        "Link your gamertag with `/link-gamertag` to show up as a tagged contributor.",
+        `Link your gamertag with </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> to show up as a tagged contributor.`,
       embeds: embeds,
     });
     await message.react(HALOFUNTIME_ID_EMOJI_HALOFUNTIME_DOT_COM);

--- a/cron/trailblazers.js
+++ b/cron/trailblazers.js
@@ -13,6 +13,8 @@ const {
   HALOFUNTIME_ID_ROLE_TRAILBLAZER,
   HALOFUNTIME_ID_ROLE_TRAILBLAZER_TITAN,
   HALOFUNTIME_ID,
+  LINK_GAMERTAG_ID,
+  LINK_GAMERTAG_NAME,
 } = require("../constants.js");
 const scheduledEvents = require("../utils/scheduledEvents");
 const { ERA_DATA } = require("../utils/eras");
@@ -383,7 +385,7 @@ const trailblazerDailyPassionReport = async (client) => {
       .setColor(0xf93a2f)
       .setTitle(`__Daily Passion Report: <t:${now.unix()}:D>__`)
       .setDescription(
-        "Every day we check each Trailblazer's passion in the Ranked Arena playlist. Link your gamertag with `/link-gamertag` to be included."
+        `Every day we check each Trailblazer's passion in the Ranked Arena playlist. Link your gamertag with </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> to be included.`
       )
       .setFooter({
         text: `"${passionReportQuip}"`,

--- a/cron/trailblazers.js
+++ b/cron/trailblazers.js
@@ -18,6 +18,7 @@ const {
 } = require("../constants.js");
 const scheduledEvents = require("../utils/scheduledEvents");
 const { ERA_DATA } = require("../utils/eras");
+const { getApplicationCommandMention } = require("../utils/formatting.js");
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -381,11 +382,15 @@ const trailblazerDailyPassionReport = async (client) => {
     const trailblazersChannel = client.channels.cache.get(
       HALOFUNTIME_ID_CHANNEL_TRAILBLAZERS
     );
+    const command = await getApplicationCommandMention(
+      LINK_GAMERTAG_NAME,
+      interaction.client
+    );
     const passionReportEmbed = new EmbedBuilder()
       .setColor(0xf93a2f)
       .setTitle(`__Daily Passion Report: <t:${now.unix()}:D>__`)
       .setDescription(
-        `Every day we check each Trailblazer's passion in the Ranked Arena playlist. Link your gamertag with </${LINK_GAMERTAG_NAME}:${LINK_GAMERTAG_ID}> to be included.`
+        `Every day we check each Trailblazer's passion in the Ranked Arena playlist. Link your gamertag with ${command} to be included.`
       )
       .setFooter({
         text: `"${passionReportQuip}"`,

--- a/events/ready.js
+++ b/events/ready.js
@@ -1,4 +1,4 @@
-const { ActivityType } = require("discord.js");
+const { ActivityType, Client } = require("discord.js");
 
 module.exports = {
   name: "ready",
@@ -8,5 +8,8 @@ module.exports = {
     client.user.setActivity("instructions", {
       type: ActivityType.Listening,
     });
+
+    // create application command cache
+    client.application.commands.fetch();
   },
 };

--- a/utils/formatting.js
+++ b/utils/formatting.js
@@ -1,0 +1,19 @@
+const { Client } = require("discord.js");
+
+/**
+ * Gets the application command mention
+ * @param {String} name
+ * @param {Client} client
+ */
+async function getApplicationCommandMention(name, client) {
+  const command = client.application.commands.cache.find((e) => e.name == name);
+  if (!command) {
+    console.warn(`Failed to fetch command "${name}"`);
+    return `\`/${name}\``;
+  }
+  return `</${command.name}:${command.id}>`;
+}
+
+module.exports = {
+  getApplicationCommandMention,
+};


### PR DESCRIPTION
This adds better formatting for slash commands using Discord's new slash command formatting ([docs](https://discord.com/developers/docs/reference#message-formatting-formats)), which looks like this:

![Discord_JR2BFxWsvD](https://github.com/HaloFunTime/hft-intern/assets/81275769/97102377-9b0e-4171-b01f-dedc2318a9ed)

It's also interactable, so users can execute the command quicker.

### Configuring the command ID
> [!NOTE]
> Make sure `Developer Mode` is enabled!
1. Type `/link-gamertag`
1. Right click the box above with the name and description of the command
1. Click `Copy Command ID`
1. Replace `LINK_GAMERTAG_ID` in [`constants.js`](https://github.com/Turtlepaw/hft-intern/blob/ebe421ceb145760829c74cebc20a1f71fb2e0c77/constants.js#L116) with the ID you've copied

![Discord_2Uk0760THN](https://github.com/HaloFunTime/hft-intern/assets/81275769/30183d3f-42b9-4886-872d-bf565e67f55a)
